### PR TITLE
Added a script to install the project dependencies.

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,0 +1,4 @@
+apt-get install postgresql
+apt-get install python-psycopg2
+apt-get install python-django
+


### PR DESCRIPTION
Simple script to install the server and database's runtime dependencies.  Use this when setting up your local dev environment, and add to it if you add any additional dependencies.