### PR TITLE
Added python-openid to the install-deps script.

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -2,3 +2,15 @@ apt-get install postgresql
 apt-get install python-psycopg2
 apt-get install python-django
 
+cd $(dirname $0)/..
+
+if [-d python-openid]; then
+	cd python-openid
+	git pull
+else
+	git clone git@github.com:openid/python-openid.git
+	cd python-openid
+fi
+
+python setup.py install
+


### PR DESCRIPTION
The github page for python-openid seems to recommend installing from source, so the script clones the repo and runs the included setup.py file.