### PR TITLE
Enabled specifying skills in the query string when fetching jobs.

### DIFF
--- a/web/job_seeking/tests.py
+++ b/web/job_seeking/tests.py
@@ -165,7 +165,35 @@ class JobSeekingAPITest(TestCase):
 
 		self.assertEquals(0, len(data))
 
-	# TODO: Test skills and regions
+	def test_get_jobs_with_skill(self):
+		bob = JobPoster.objects.get(name="Bob")
+
+		python_posting = new_job_posting(poster=bob)
+		python_posting.save()
+		python_posting.jobskill_set.add(JobSkill(skill="python"))
+
+		django_posting = new_job_posting(poster=bob)
+		django_posting.save()
+		django_posting.jobskill_set.add(JobSkill(skill="django"))
+
+		java_posting = new_job_posting(poster=bob)
+		java_posting.save()
+		java_posting.jobskill_set.add(JobSkill(skill="java"))
+
+		response = self.client.get(
+			get_url("job_seeking:jobs"),
+			{"skill" : ["python", "django"]}
+		)
+		data = loads(response.content)
+
+		self.assertEquals(200, response.status_code)
+		self.assertEquals(2, len(data))
+		self.assertEquals(
+			{python_posting.id, django_posting.id},
+			{posting["id"] for posting in data}
+		)
+
+	# TODO: Test regions
 
 	def test_get_job_poster(self):
 		bob = JobPoster.objects.get(name="Bob")

--- a/web/job_seeking/views.py
+++ b/web/job_seeking/views.py
@@ -66,13 +66,13 @@ class ProfileView(APIView):
 		return request.user
 
 
+# TODO: Region
 class JobsView(APIView):
 	@serialize_response(default_serializer(JobPosting), many=True)
 	def get(self, request):
-		return get_jobs(request.user)
+		return get_jobs(request.user, request.GET.getlist("skill"))
 
 
-# TODO: Skills and region
 class JobPosterView(APIView):
 	@serialize_response(SecureJobPosterSerializer)
 	def get(self, request, poster_id):


### PR DESCRIPTION
@msabbasi This will allow you to specify multiple skills in the query string, as in "http://<address>/job_seeking/jobs/?skill=python&skill=java".