### PR TITLE
Raised the limit on the registration id field to 500 characters.

### DIFF
--- a/web/small_jobs_api/models.py
+++ b/web/small_jobs_api/models.py
@@ -87,7 +87,7 @@ class Contractor(Model):
 	description = NullableTextField()
 	email = ShortCharField(unique=True, validators=[validate_email])
 	phone_number = NullableShortCharField(validators=[validate_phone_number])
-	registration_id = ShortCharField()
+	registration_id = CharField(max_length=500, default=None)
 
 	def save(self):
 		self.full_clean()


### PR DESCRIPTION
@msabbasi I think 500 should be enough.  You can raise it further if it's not.