### PR TITLE
Enabled contractors to update their profiles.

### DIFF
--- a/web/job_seeking/tests.py
+++ b/web/job_seeking/tests.py
@@ -151,6 +151,22 @@ class JobSeekingAPITest(TestCase):
 		self.assertEquals(emily.name, data['name'])
 		self.assertEquals(emily.email, data['email'])
 
+	def test_update_profile(self):
+		emily = Contractor.objects.get(name="Emily")
+		update_data = {
+			"name" : "Emily Durkheim",
+			"registration_id" : "1",
+			"email" : "emilyd98@gmail.com"
+		}
+
+		response = self.client.post(get_url("job_seeking:profile"), update_data)
+		self.assertEquals(201, response.status_code)
+
+		new_emily = Contractor.objects.get(id=emily.id)
+		self.assertEquals(update_data["name"], new_emily.name)
+		self.assertEquals(update_data["registration_id"], new_emily.registration_id)
+		self.assertEquals(update_data["email"], new_emily.email)
+
 	def test_get_jobs(self):
 		bob = JobPoster.objects.get(name="Bob")
 		posting = new_job_posting(poster=bob)

--- a/web/job_seeking/views.py
+++ b/web/job_seeking/views.py
@@ -65,6 +65,12 @@ class ProfileView(APIView):
 	def get(self, request):
 		return request.user
 
+	@deserialize_request(default_serializer(Contractor))
+	def post(self, request, contractor):
+		contractor.id = request.user.id
+		update_contractor(contractor)
+		return Response("OK", status=201)
+
 
 class JobsView(APIView):
 	@serialize_response(default_serializer(JobPosting), many=True)

--- a/web/small_jobs_api/models.py
+++ b/web/small_jobs_api/models.py
@@ -76,7 +76,8 @@ class JobPoster(Model):
 	region = NullableShortCharField()
 
 	def save(self):
-		self.full_clean()
+		self.clean_fields()
+		self.clean()
 		super(JobPoster, self).save()
 
 	def __unicode__(self):
@@ -90,7 +91,8 @@ class Contractor(Model):
 	registration_id = CharField(max_length=500, default=None)
 
 	def save(self):
-		self.full_clean()
+		self.clean_fields()
+		self.clean()
 		super(Contractor, self).save()
 
 	def is_authenticated(self):
@@ -116,7 +118,8 @@ class JobPosting(Model):
 	date_completed = NullableDateTimeField()
 
 	def save(self):
-		self.full_clean()
+		self.clean_fields()
+		self.clean()
 		super(JobPosting, self).save()
 
 	def __init__(self, *args, **kwargs):
@@ -173,7 +176,8 @@ class Bid(Model):
 	completion_date = NullableDateTimeField()
 
 	def save(self):
-		self.full_clean()
+		self.clean_fields()
+		self.clean()
 		super(Bid, self).save()
 
 	# TODO: Consider the following -
@@ -217,7 +221,8 @@ class JobSkill(Model):
 	skill = ShortCharField(db_index=True)
 
 	def save(self):
-		self.full_clean()
+		self.clean_fields()
+		self.clean()
 		super(JobSkill, self).save()
 
 	class Meta:
@@ -231,7 +236,8 @@ class ContractorSkill(Model):
 	skill = ShortCharField(db_index=True)
 
 	def save(self):
-		self.full_clean()
+		self.clean_fields()
+		self.clean()
 		super(ContractorSkill, self).save()
 
 	class Meta:
@@ -248,7 +254,8 @@ class JobPosterRating(Model):
 	)
 	
 	def save(self):
-		self.full_clean()
+		self.clean_fields()
+		self.clean()
 		super(JobPosterRating, self).save()
 
 	class Meta:
@@ -267,7 +274,8 @@ class ContractorRating(Model):
 	)
 
 	def save(self):
-		self.full_clean()
+		self.clean_fields()
+		self.clean()
 		super(ContractorRating, self).save()
 
 	class Meta:


### PR DESCRIPTION
@msabbasi This will allow you to post to the profile endpoint.  Make sure to include the whole contractor object, not just the changes, otherwise the missing fields will be set to null.
The ID is optional, and will be completely ignored.